### PR TITLE
Fix alignment-predict.

### DIFF
--- a/reporter/predict.py
+++ b/reporter/predict.py
@@ -2,7 +2,7 @@ import argparse
 import errno
 import itertools
 import os
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import List
 
@@ -165,7 +165,6 @@ def make_alignment_for_prediction(r: Redis,
                                   t: str,
                                   seqtypes: List[SeqType]) -> Alignment:
     time = datetime.strptime(t, NIKKEI_DATETIME_FORMAT)
-    delta = timedelta(days=10)
 
     chart = dict()
     for (ric, seqtype) in itertools.product(rics, seqtypes):


### PR DESCRIPTION
`predict.py` の `load_alignments_from_db` を `make_alignment_for_prediction` に変更し、
`redis.keys` で key 検索を行う部分を削除しました。
代わりに、postgres で時間検索を行ってから key を作成し chart の値を取得するようにしました。
