### PR TITLE
Fix write.py. Do not use `is_template` in default.

### DIFF
--- a/reporter/database/write.py
+++ b/reporter/database/write.py
@@ -317,7 +317,7 @@ def update_headlines(session: Session, user_dict: Path, logger: Logger) -> None:
         is_about_di = headline.categories is not None and \
             DOMESTIC_INDEX in headline.categories
 
-        # Do not use `is_template` because of the number of data reduces.
+        # We stopped using `is_template` because the size of the dataset decreased and the result got worse.
         # if is_template(h) or not is_interesting(h) or not is_about_di:
         if not is_interesting(h) or not is_about_di:            
             mappings.append({


### PR DESCRIPTION
データ数が減るため、デフォルトでは `is_template` を使用しない
使用する場合はコメントアウトを取り除くようにする